### PR TITLE
Add simple CXL Switch QEMU device

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@ root = true
 
 [*]
 end_of_line = lf
-insert_final_newline = true
+insert_final_newline = false
 charset = utf-8
 
 [*.mak]

--- a/hw/misc/Kconfig
+++ b/hw/misc/Kconfig
@@ -25,6 +25,11 @@ config PCI_TESTDEV
     default y if TEST_DEVICES
     depends on PCI
 
+config CXL_SWITCH
+    bool
+    default y if PCI_DEVICES
+    depends on PCI && LINUX && IVSHMEM && MSI_NONBROKEN
+
 config EDU
     bool
     default y if TEST_DEVICES

--- a/hw/misc/cxl-switch.c
+++ b/hw/misc/cxl-switch.c
@@ -206,7 +206,7 @@ static const MemoryRegionOps cxl_switch_mem_ops = {
 static void pci_cxl_switch_realize(PCIDevice *pdev, Error **errp)
 {
     CXLSwitchState *s = CXL_SWITCH(pdev);
-    CXL_SWITCH_DPRINTF("Info: Realizing device.\n"); // Added device ID manually
+    CXL_SWITCH_DPRINTF("Info: Realizing device with mem-size %"PRIu64".\n", s->mem_size); // Added device ID manually
 
     if (s->mem_size == 0) {
         error_setg(errp, "CXL Switch (%s): mem-size property must be set", object_get_canonical_path_component(OBJECT(s)));
@@ -300,8 +300,7 @@ static void cxl_switch_class_init(ObjectClass *klass, const void *data)
 static void cxl_switch_instance_init(Object *obj)
 {
     CXLSwitchState *s = CXL_SWITCH(obj);
-    // TODO: Let user specify this
-    s->mem_size = 128 * MiB; // Default size
+    s->mem_size = 128 * MiB; // Default size, will be overridden by actual setting
     for (int i = 0; i < 3; i++) {
         s->backing_mem_id[i] = NULL;
     }

--- a/hw/misc/cxl-switch.c
+++ b/hw/misc/cxl-switch.c
@@ -1,0 +1,329 @@
+#include "qemu/osdep.h"
+#include "qemu/log.h"
+#include "qemu/typedefs.h"
+#include "qemu/units.h"
+#include "hw/pci/pci.h"
+#include "hw/pci/pci_device.h"
+#include "hw/hw.h"
+#include "hw/pci/msi.h"
+#include "hw/qdev-properties.h"
+#include "qemu/timer.h"
+#include "qom/object.h"
+#include "qemu/main-loop.h" /* iothread mutex */
+#include "qemu/module.h"
+#include "qapi/visitor.h"
+#include "standard-headers/linux/pci_regs.h"
+#include "system/memory.h"
+#include "system/hostmem.h"
+#include <sys/types.h>
+
+#define CXL_SWITCH_DEBUG 1
+#define CXL_SWITCH_DPRINTF(fmt, ...)                       \
+    do {                                                   \
+        if (CXL_SWITCH_DEBUG) {                            \
+            printf("CXL Switch: " fmt, ## __VA_ARGS__);    \
+        }                                                  \
+    } while (0)
+
+
+#define TYPE_PCI_CXL_SWITCH "cxl-switch"
+
+typedef struct CXLSwitchState CXLSwitchState;
+DECLARE_INSTANCE_CHECKER(CXLSwitchState, CXL_SWITCH, TYPE_PCI_CXL_SWITCH)
+
+#define PCI_VENDOR_ID_QEMU_CXL_SWITCH 0x1AF4
+#define PCI_CXL_DEVICE_ID 0x1337
+
+typedef enum {
+    BACKEND_STATUS_HEALTHY = 0,
+    BACKEND_STATUS_FAILED = 1,
+} BackendHealthStatus;
+
+/**
+    TODO: We will need a way to keep track of active memory regions
+          for allocation/deallocation.
+          At the moment, we are just using a static array of 3 and concerned
+          with getting the replication right.
+*/
+
+struct CXLSwitchState {
+    PCIDevice pdev;
+
+    /* The total replicated memory */
+    uint64_t mem_size;
+    MemoryRegion replicated_mr;  // BAR2: Guest access
+
+    /* 
+        The "emulated" CXL memory devices
+        TODO: Support more than 3 memory devices in the future. 
+    */
+    HostMemoryBackend *backing_hmb[3];
+    MemoryRegion *backing_mr[3];
+    char *backing_mem_id[3]; // Initialized with 3 memdevs, identifies them
+    BackendHealthStatus health_status[3];
+
+    QemuMutex lock; // Protects backing_health which can be concurrently modified
+};
+
+static void pci_cxl_switch_register_types(void);
+static void cxl_switch_instance_init(Object *obj);
+static void cxl_switch_class_init(ObjectClass *class, const void *data);
+static void pci_cxl_switch_realize(PCIDevice *pdev, Error **errp);
+static void pci_cxl_switch_uninit(PCIDevice *pdev);
+
+/* BAR2 Replicated Memory Operations */
+
+static uint64_t cxl_switch_mem_read(void *opaque, hwaddr addr, unsigned size)
+{
+    CXLSwitchState *s = opaque;
+    uint64_t data = ~0ULL; // Default error value (all FFs)
+    
+    int replica_to_read = -1;
+    if ((addr + size) > s->mem_size) {
+        CXL_SWITCH_DPRINTF("GuestError: Read out of bounds (offset=0x%"PRIx64", size=%u, limit=0x%"PRIx64")\n",
+                      addr, size, s->mem_size);
+        return data;
+    }
+
+    /* We lock here as multiple VMs could perform read ops concurrently */
+    qemu_mutex_lock(&s->lock);
+
+    /* Find a healthy backend */
+    for (int i = 0; i < 3; i++) {
+        if (s->health_status[i] == BACKEND_STATUS_HEALTHY) {
+            replica_to_read = i;
+            break;
+        }
+    }
+
+    if (replica_to_read == -1) {
+        CXL_SWITCH_DPRINTF("GuestError: No healthy backend found for read (offset=0x%"PRIx64", size=%u)\n",
+                      addr, size);
+        qemu_mutex_unlock(&s->lock);
+        return data;
+    }
+
+    if (s->backing_mr[replica_to_read]) {
+        uint8_t *ram_ptr = memory_region_get_ram_ptr(s->backing_mr[replica_to_read]);
+        if (ram_ptr) {
+            switch (size) {
+                case 1: data = ldub_p(ram_ptr + addr); break;
+                case 2: data = lduw_le_p(ram_ptr + addr); break;
+                case 4: data = ldl_le_p(ram_ptr + addr); break;
+                case 8: data = ldq_le_p(ram_ptr + addr); break;
+                default:
+                    CXL_SWITCH_DPRINTF("GuestError: Unsupported read size %u from replica %d at offset 0x%"PRIx64"\n",
+                                  size, replica_to_read, addr);
+                    data = ~0ULL;
+                    break;
+            }
+        } else {
+            /* TODO: This should not happen, but if it does, we should try again */
+            CXL_SWITCH_DPRINTF("GuestError: Replica %d backing RAM not available for read at offset 0x%"PRIx64". Marking FAILED.\n",
+                          replica_to_read, addr);
+            s->health_status[replica_to_read] = BACKEND_STATUS_FAILED;
+            data = ~0ULL;
+        }
+    }
+
+    qemu_mutex_unlock(&s->lock);
+    return data;
+}
+
+static void cxl_switch_mem_write(void *opaque, hwaddr addr, uint64_t val, unsigned size)
+{
+    CXLSwitchState *s = opaque;
+    int successful_writes = 0;
+    int num_healthy_backends_attempted = 0;
+
+    if ((addr + size) > s->mem_size) {
+        CXL_SWITCH_DPRINTF("GuestError: Write out of bounds (offset=0x%"PRIx64", size=%u, limit=0x%"PRIx64")\n",
+                      addr, size, s->mem_size);
+        return;
+    }
+
+    qemu_mutex_lock(&s->lock);
+
+    for (int i = 0; i < 3; i++) {
+        if (s->health_status[i] != BACKEND_STATUS_HEALTHY) {
+            continue;
+        }
+        num_healthy_backends_attempted++;
+
+        if (s->backing_mr[i]) {
+            uint8_t *ram_ptr = memory_region_get_ram_ptr(s->backing_mr[i]);
+            if (ram_ptr) {
+                bool write_ok = true;
+                switch (size) {
+                    case 1: stl_p(ram_ptr + addr, (uint8_t) val); break;
+                    case 2: stw_le_p(ram_ptr + addr, (uint16_t) val); break;
+                    case 4: stl_le_p(ram_ptr + addr, (uint32_t) val); break;
+                    case 8: stq_le_p(ram_ptr + addr, val); break;
+                    default:
+                        CXL_SWITCH_DPRINTF("GuestError: Unsupported write size %u to replica %d at offset 0x%"PRIx64"\n",
+                                      size, i, addr);
+                        write_ok = false;
+                        break;
+                }
+                if (write_ok) {
+                    successful_writes++;
+                }
+            } else {
+                CXL_SWITCH_DPRINTF("GuestError: Replica %d backing RAM not available for write at offset 0x%"PRIx64". Marking FAILED.\n",
+                              i, addr);
+                s->health_status[i] = BACKEND_STATUS_FAILED;
+            }
+        } else {
+            CXL_SWITCH_DPRINTF("GuestError: Replica %d backing memory region not available for write at offset 0x%"PRIx64"\n",
+                          i, addr);
+            s->health_status[i] = BACKEND_STATUS_FAILED;
+        }
+    }
+
+    qemu_mutex_unlock(&s->lock);
+
+    if (num_healthy_backends_attempted > 0 && successful_writes < num_healthy_backends_attempted) {
+        CXL_SWITCH_DPRINTF("GuestError: Write to offset 0x%"PRIx64" succeeded on %d/%d healthy backends.\n",
+                      addr, successful_writes, num_healthy_backends_attempted);
+    } else if (num_healthy_backends_attempted == 0 && s->mem_size > 0) {
+         CXL_SWITCH_DPRINTF("GuestError: Write to offset 0x%"PRIx64" failed: No healthy backends available.\n",
+                      addr);
+    }
+}
+
+static const MemoryRegionOps cxl_switch_mem_ops = {
+    .read = cxl_switch_mem_read,
+    .write = cxl_switch_mem_write,
+    .endianness = DEVICE_LITTLE_ENDIAN,
+    .impl = {
+        .min_access_size = 1,
+        .max_access_size = 8,
+    },
+};
+
+/* PCI Device Lifecycle */
+
+static void pci_cxl_switch_realize(PCIDevice *pdev, Error **errp)
+{
+    CXLSwitchState *s = CXL_SWITCH(pdev);
+    CXL_SWITCH_DPRINTF("Info: Realizing device.\n"); // Added device ID manually
+
+    if (s->mem_size == 0) {
+        error_setg(errp, "CXL Switch (%s): mem-size property must be set", object_get_canonical_path_component(OBJECT(s)));
+        return;
+    }
+
+    qemu_mutex_init(&s->lock);
+
+    /* Init all backing stores to healthy */
+    for (int i = 0; i < 3; i++) {
+        s->health_status[i] = BACKEND_STATUS_HEALTHY;
+        if (!s->backing_mem_id[i] || strlen(s->backing_mem_id[i]) == 0) {
+            error_setg(errp, "CXL Switch (%s): memdev%d property must be set for backend %d", object_get_canonical_path_component(OBJECT(s)), i, i);
+            return;
+        }
+        bool ambiguous;
+        Object *obj = object_resolve_path(s->backing_mem_id[i], &ambiguous);
+        // TODO: handle ambiguous case
+        if (!obj) {
+            error_setg(errp, "CXL Switch (%s): Unable to find HostMemoryBackend '%s' for backend %d", object_get_canonical_path_component(OBJECT(s)), s->backing_mem_id[i], i);
+            return;
+        }
+        s->backing_hmb[i] = MEMORY_BACKEND(obj);
+        if (!s->backing_hmb[i]) {
+            error_setg(errp, "CXL Switch (%s): Object '%s' is not a HostMemoryBackend for backend %d", object_get_canonical_path_component(OBJECT(s)), s->backing_mem_id[i], i);
+            return;
+        }
+        if (host_memory_backend_is_mapped(s->backing_hmb[i])) {
+            error_setg(errp, "CXL Switch (%s): HostMemoryBackend '%s' for backend %d is already in use.", object_get_canonical_path_component(OBJECT(s)), s->backing_mem_id[i], i);
+            return;
+        }
+        s->backing_mr[i] = host_memory_backend_get_memory(s->backing_hmb[i]);
+        if (!s->backing_mr[i] || memory_region_size(s->backing_mr[i]) < s->mem_size) {
+            error_setg(errp, "CXL Switch (%s): Backend %d ('%s') memory region is too small or invalid (size: %"PRIu64", required: %"PRIu64")", 
+                object_get_canonical_path_component(OBJECT(s)), i, s->backing_mem_id[i], s->backing_mr[i] ? memory_region_size(s->backing_mr[i]) : 0, s->mem_size);
+            return;
+        }
+        host_memory_backend_set_mapped(s->backing_hmb[i], true);
+        CXL_SWITCH_DPRINTF("Info: Backend %d ('%s') initialized, size %"PRIu64".\n",
+                    i, s->backing_mem_id[i], memory_region_size(s->backing_mr[i]));
+    }
+
+    // BAR2: replicated memory pool
+    memory_region_init_io(&s->replicated_mr, OBJECT(s), &cxl_switch_mem_ops, s, "cxl-switch-replicated-mem", s->mem_size);
+    pci_register_bar(pdev, 0, PCI_BASE_ADDRESS_SPACE_MEMORY | PCI_BASE_ADDRESS_MEM_TYPE_64 | PCI_BASE_ADDRESS_MEM_PREFETCH, &s->replicated_mr);
+    CXL_SWITCH_DPRINTF("Info: BAR0 (effectively BAR2) registered for replication, size %"PRIu64".\n", s->mem_size);
+
+    // TODO: No BAR0 for MMIO commands here
+    // TODO: No chardev here as well
+}
+
+static void pci_cxl_switch_uninit(PCIDevice *pdev)
+{
+    CXLSwitchState *s = CXL_SWITCH(pdev);
+    CXL_SWITCH_DPRINTF("Info: Uninitializing device.\n");
+
+    for (int i = 0; i < 3; i++) {
+        if (s->backing_hmb[i] && host_memory_backend_is_mapped(s->backing_hmb[i])) {
+            host_memory_backend_set_mapped(s->backing_hmb[i], false);
+        }
+    }
+
+    qemu_mutex_destroy(&s->lock);
+}
+
+/** QOM Type Registration */
+static Property cxl_switch_properties[] = {
+    DEFINE_PROP_SIZE("mem-size", CXLSwitchState, mem_size, 0),
+    DEFINE_PROP_STRING("memdev0", CXLSwitchState, backing_mem_id[0]),
+    DEFINE_PROP_STRING("memdev1", CXLSwitchState, backing_mem_id[1]),
+    DEFINE_PROP_STRING("memdev2", CXLSwitchState, backing_mem_id[2]),
+};
+
+static void cxl_switch_class_init(ObjectClass *klass, const void *data)
+{
+    DeviceClass *dc = DEVICE_CLASS(klass);
+    PCIDeviceClass *k = PCI_DEVICE_CLASS(klass);
+
+    k->realize = pci_cxl_switch_realize;
+    k->exit = pci_cxl_switch_uninit;
+    k->vendor_id = PCI_VENDOR_ID_QEMU_CXL_SWITCH;
+    k->device_id = PCI_CXL_DEVICE_ID;
+    k->class_id = PCI_CLASS_MEMORY_RAM;
+    k->revision = 1;
+
+    device_class_set_props(dc, cxl_switch_properties);
+    set_bit(DEVICE_CATEGORY_MISC, dc->categories);
+    dc->desc = "CXL Switch";
+}
+
+static void cxl_switch_instance_init(Object *obj)
+{
+    CXLSwitchState *s = CXL_SWITCH(obj);
+    // TODO: Let user specify this
+    s->mem_size = 128 * MiB; // Default size
+    for (int i = 0; i < 3; i++) {
+        s->backing_mem_id[i] = NULL;
+    }
+}
+
+static InterfaceInfo interfaces[] = {
+    { INTERFACE_CONVENTIONAL_PCI_DEVICE },
+    { },
+};
+
+static const TypeInfo cxl_switch_info = {
+    .name = TYPE_PCI_CXL_SWITCH,
+    .parent = TYPE_PCI_DEVICE,
+    .instance_size = sizeof(CXLSwitchState),
+    .instance_init = cxl_switch_instance_init,
+    .class_init = cxl_switch_class_init,
+    .interfaces = interfaces,
+};
+
+static void pci_cxl_switch_register_types(void)
+{
+    type_register_static(&cxl_switch_info);
+}
+
+type_init(pci_cxl_switch_register_types);

--- a/hw/misc/meson.build
+++ b/hw/misc/meson.build
@@ -40,6 +40,7 @@ subdir('macio')
 # ivshmem devices
 system_ss.add(when: 'CONFIG_IVSHMEM_DEVICE', if_true: files('ivshmem-pci.c'))
 system_ss.add(when: 'CONFIG_IVSHMEM_FLAT_DEVICE', if_true: files('ivshmem-flat.c'))
+system_ss.add(when: 'CONFIG_CXL_SWITCH', if_true: files('cxl-switch.c'))
 
 system_ss.add(when: 'CONFIG_ALLWINNER_SRAMC', if_true: files('allwinner-sramc.c'))
 system_ss.add(when: 'CONFIG_ALLWINNER_A10_CCM', if_true: files('allwinner-a10-ccm.c'))

--- a/image.sh
+++ b/image.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+sudo apt-get install cloud-image-utils qemu
+
+# This is already in qcow2 format.
+img=ubuntu-18.04-server-cloudimg-amd64.img
+if [ ! -f "$img" ]; then
+  wget "https://cloud-images.ubuntu.com/releases/18.04/release/${img}"
+
+  # sparse resize: does not use any extra space, just allows the resize to happen later on.
+  # https://superuser.com/questions/1022019/how-to-increase-size-of-an-ubuntu-cloud-image
+  qemu-img resize "$img" +128G
+fi
+
+user_data=user-data.img
+if [ ! -f "$user_data" ]; then
+  # For the password.
+  # https://stackoverflow.com/questions/29137679/login-credentials-of-ubuntu-cloud-server-image/53373376#53373376
+  # https://serverfault.com/questions/920117/how-do-i-set-a-password-on-an-ubuntu-cloud-image/940686#940686
+  # https://askubuntu.com/questions/507345/how-to-set-a-password-for-ubuntu-cloud-images-ie-not-use-ssh/1094189#1094189
+  cat >user-data <<EOF
+#cloud-config
+password: asdfqwer
+chpasswd: { expire: False }
+ssh_pwauth: True
+EOF
+  cloud-localds "$user_data" user-data
+fi
+
+./build/qemu-system-x86_64 \
+    -m 2G \
+    -smp 2 \
+    -drive "file=${img},format=qcow2" \
+    -drive "file=${user_data},format=raw" \
+    -nographic \
+    -enable-kvm \
+    -vga std \
+    -device virtio-net-pci,netdev=net0 -netdev user,id=net0 \
+    -object memory-backend-file,id=my-memdev0,size=128M,mem-path=/home/jotham/qemu-cxl-shm/replica0.img,share=on \
+    -object memory-backend-file,id=my-memdev1,size=128M,mem-path=/home/jotham/qemu-cxl-shm/replica1.img,share=on \
+    -object memory-backend-file,id=my-memdev2,size=128M,mem-path=/home/jotham/qemu-cxl-shm/replica2.img,share=on \
+    -device cxl-switch,id=cxlsw0,mem-size=128M,memdev0=my-memdev0,memdev1=my-memdev1,memdev2=my-memdev2

--- a/image.sh
+++ b/image.sh
@@ -38,6 +38,9 @@ for i in $(seq 0 $((NUM_REPLICAS - 1))); do
   chmod 666 "$replica_file"
 done
 
+# Sharing folder on the VM
+# https://dev.to/franzwong/mount-share-folder-in-qemu-with-same-permission-as-host-2980
+# sudo mount -t 9p -o trans=virtio,version=9p2000.L shared /mnt/shared
 
 ./build/qemu-system-x86_64 \
     -m 2G \
@@ -51,4 +54,5 @@ done
     -object memory-backend-file,id=my-memdev0,size=${REPLICA_SIZE},mem-path=/home/jotham/qemu-cxl-shm/replica0.img,share=on \
     -object memory-backend-file,id=my-memdev1,size=${REPLICA_SIZE},mem-path=/home/jotham/qemu-cxl-shm/replica1.img,share=on \
     -object memory-backend-file,id=my-memdev2,size=${REPLICA_SIZE},mem-path=/home/jotham/qemu-cxl-shm/replica2.img,share=on \
-    -device cxl-switch,id=cxlsw0,mem-size=${REPLICA_SIZE},memdev0=my-memdev0,memdev1=my-memdev1,memdev2=my-memdev2
+    -device cxl-switch,id=cxlsw0,mem-size=${REPLICA_SIZE},memdev0=my-memdev0,memdev1=my-memdev1,memdev2=my-memdev2 \
+    -virtfs local,path=qemu_share,mount_tag=shared,security_model=mapped-xattr

--- a/image.sh
+++ b/image.sh
@@ -7,9 +7,9 @@ REPLICA_SIZE="256M"
 NUM_REPLICAS=3
 
 # This is already in qcow2 format.
-img=ubuntu-18.04-server-cloudimg-amd64.img
+img=ubuntu-22.04-server-cloudimg-amd64.img
 if [ ! -f "$img" ]; then
-  wget "https://cloud-images.ubuntu.com/releases/18.04/release/${img}"
+  wget "https://cloud-images.ubuntu.com/releases/22.04/release/${img}"
 
   # sparse resize: does not use any extra space, just allows the resize to happen later on.
   # https://superuser.com/questions/1022019/how-to-increase-size-of-an-ubuntu-cloud-image
@@ -39,12 +39,12 @@ for i in $(seq 0 $((NUM_REPLICAS - 1))); do
 done
 
 # Sharing folder on the VM
-# https://dev.to/franzwong/mount-share-folder-in-qemu-with-same-permission-as-host-2980
+# https://dev.to/franzwong/mount-share-mkfolder-in-qemu-with-same-permission-as-host-2980
 # sudo mount -t 9p -o trans=virtio,version=9p2000.L shared /mnt/shared
 
 ./build/qemu-system-x86_64 \
-    -m 2G \
-    -smp 2 \
+    -m 16G \
+    -smp 12 \
     -drive "file=${img},format=qcow2" \
     -drive "file=${user_data},format=raw" \
     -nographic \

--- a/jotham_notes.md
+++ b/jotham_notes.md
@@ -1,0 +1,130 @@
+# Log
+
+## 23 May
+
+Here is what has been achieved so far as of 23 May.
+
+There are 3 main things of interest:
+
+1. CXL Switch QEMU Device
+2. CXL Switch Device Driver module
+3. CXL Switch user-space program
+
+### CXL Switch QEMU Device
+
+Uses 3 host-backed memory files for replication.
+Replicates stores to the regions.
+Route load from one region.
+
+### CXL Switch Device Driver Module
+
+Registers the QEMU device which is `/dev/cxl-switch`
+
+### User-space program
+
+Uses `mmap` to map the memory region exposed by the CXL Switch.
+Writes to it.
+Manually read the memory files with hexdump.
+
+### What's happening
+
+A. Initialization & Device Setup Phase:
+
+    QEMU Startup & Device Definition:
+        Start QEMU, providing arguments to instantiate your cxl-switch device. Example: -device cxl-switch,id=mycxl,mem-size=256M,memdev0=ram0,memdev1=ram1,memdev2=ram2.
+        You also define the host memory backends: -object memory-backend-file,id=ram0,size=256M,mem-path=/tmp/ram0.img,share=on (and similarly for ram1, ram2). These .img files will physically store the replicated data on the host.
+
+    QEMU Type Registration (type_init(pci_cxl_switch_register_types)):
+        The cxl_switch_info (a TypeInfo struct) is registered with QEMU's type system, defining the cxl-switch device type.
+
+    QEMU Instance Init (cxl_switch_instance_init):
+        When QEMU creates an instance of cxl-switch, this function runs. It sets a default s->mem_size (e.g., 128MiB, but this will be overridden by the mem-size=256M property) and initializes s->backing_mem_id pointers to NULL.
+
+    QEMU Device Realization (pci_cxl_switch_realize):
+        This is a key PCI device lifecycle function in QEMU.
+        It reads the mem-size (256MB from your command line) and memdev0/1/2 string properties (e.g., "ram0", "ram1", "ram2") into the CXLSwitchState *s.
+        Initializes s->lock (a QemuMutex for protecting concurrent access to shared device state like health_status and during read/write operations).
+
+    Link to Host Backing Stores:
+        For each memdevX property (e.g., "ram0"):
+            object_resolve_path("ram0", ...) finds the HostMemoryBackend object you defined with -object memory-backend-file,id=ram0,....
+            This HostMemoryBackend (s->backing_hmb[i]) provides the actual host memory.
+            s->backing_mr[i] = host_memory_backend_get_memory(...) gets the QEMU MemoryRegion associated with this host RAM (e.g., pointing to the mmaped /tmp/ram0.img).
+            host_memory_backend_set_mapped(s->backing_hmb[i], true) marks the backend as in use.
+
+    Initialize Guest-Visible Replicated Memory Region (s->replicated_mr):
+        memory_region_init_io(&s->replicated_mr, ..., &cxl_switch_mem_ops, s, "cxl-switch-replicated-mem", s->mem_size): This creates the primary memory region (256MB in size) that the guest OS will see.
+        It's initialized with cxl_switch_mem_ops, meaning any read/write to this region by the guest will call your cxl_switch_mem_read or cxl_switch_mem_write functions. s (the CXLSwitchState pointer) is passed as opaque data to these callbacks.
+
+    Register BAR0 (pci_register_bar):
+        pci_register_bar(pdev, 0, ..., &s->replicated_mr): This tells QEMU to expose s->replicated_mr as BAR0 of this PCI device to the guest. The flags indicate it's a 64-bit, prefetchable memory region.
+
+    QEMU Presents PCI Device to Guest:
+        The QEMU emulated CXL Switch, with Vendor ID 0x1AF4 and Device ID 0x1337, and its BAR0 (which is s->replicated_mr) are now visible on the guest's emulated PCI bus.
+
+    Guest Kernel: PCI Driver Registration (Your Linux Driver):
+        Your cxl_switch_init_module is called (e.g., via insmod).
+        pci_register_driver(&cxl_switch_driver) tells the guest Linux kernel about your driver and the PCI IDs (cxl_switch_ids) it supports.
+
+    Guest Kernel: Device Discovery & Probe (cxl_switch_pci_probe):
+        The guest kernel's PCI subsystem matches the emulated CXL switch (VID:0x1AF4, DID:0x1337) with your driver.
+        It calls your cxl_switch_pci_probe function.
+
+    Driver: Enable Device (pci_enable_device): Standard PCI device enabling.
+
+    Driver: Get BAR0 Info:
+        pci_resource_start(pdev, 0) returns the guest physical base address of BAR0 (which QEMU set to be s->replicated_mr).
+        pci_resource_len(pdev, 0) returns its size (256MB).
+
+    Driver: Request BAR0 Region (pci_request_region): Claims the BAR0 MMIO resource in the guest.
+
+    Driver: Map BAR0 to Kernel VA (pcim_iomap): dev->bar0_kva gets a kernel virtual address for BAR0. Not directly used by user mmap path but good practice.
+
+    Driver: Create Character Device (alloc_chrdev_region, etc.): Sets up the character device, associating it with cxl_switch_fops (which contains your cxl_switch_open, cxl_switch_mmap implementations).
+
+    Driver: Create Device Node (device_create): Creates /dev/cxl_switch0 in the guest's filesystem using the char device.
+
+B. Runtime Data Flow (User-Space Write via mmap):
+
+    User Program: open("/dev/cxl_switch0", O_RDWR | O_SYNC):
+        Your user-space C program opens the device file created by the driver. O_SYNC attempts to make writes synchronous, though for MMIO, caching behavior is key.
+    Guest Kernel: cxl_switch_open:
+        The VFS routes the open call to your driver's cxl_switch_open.
+    Driver: Store Context: filp->private_data is set to point to the struct cxl_switch_dev, making device-specific data available for subsequent calls like mmap.
+    User Program: mmap(NULL, MAP_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0):
+        MAP_SIZE is 256MB. PROT_READ | PROT_WRITE allows reading and writing. MAP_SHARED ensures writes are visible to the "device" (and other mappers). fd is the file descriptor from open. 0 is the offset within BAR0.
+    Guest Kernel: cxl_switch_mmap:
+        The kernel routes the mmap call to your driver's cxl_switch_mmap.
+    Driver: Calculate Physical Address & Size:
+        phys = pci_resource_start(pdev, 0) (since user offset is 0) gets the guest physical base address of BAR0.
+        vsize is set to MAP_SIZE (256MB).
+    Driver: Set Page Protections:
+        vma->vm_page_prot = pgprot_noncached(...): Crucial for MMIO. Disables CPU caching for this memory region.
+        vm_flags_set(vma, VM_IO | ...): Marks the region as I/O memory.
+    Driver: io_remap_pfn_range:
+        This guest kernel function maps the guest physical address range of BAR0 directly into the user-space program's virtual address space.
+    Mapping Complete: mmap returns a pointer (mapped_mem) to the user-space program. This pointer is a user virtual address.
+    User Program: mapped_mem[0] = 0xAABBCCDD;:
+        The user program writes a 32-bit value (0xAABBCCDD) to the start of the mapped region. volatile (used in your user code) ensures the compiler doesn't optimize away the access.
+    Guest CPU/MMU Translation:
+        The guest CPU attempts to write to the user virtual address. The guest MMU translates this to the guest physical address corresponding to the start of BAR0 (which is the start of QEMU's s->replicated_mr).
+    QEMU Hypervisor Intercepts MMIO Write:
+        QEMU detects a write to the guest physical address that falls within the MMIO range of s->replicated_mr.
+    QEMU Invokes cxl_switch_mem_write:
+        Because s->replicated_mr was initialized with cxl_switch_mem_ops, QEMU calls s->replicated_mr.ops->write, which is your cxl_switch_mem_write function.
+        opaque (which is s), addr (offset within BAR0, here 0), val (0xAABBCCDD), and size (4) are passed.
+    QEMU Device: Acquire Lock (qemu_mutex_lock(&s->lock)):
+        The mutex is locked to ensure exclusive access while performing the replicated write and checking health status.
+    QEMU Device: Replicate Write Loop:
+        The code iterates i = 0 to 2 (for the three backing stores):
+            Checks s->health_status[i].
+            ram_ptr = memory_region_get_ram_ptr(s->backing_mr[i]): Gets a direct host pointer to the memory of the i-th backing store (e.g., the mmaped content of /tmp/ram0.img).
+            stl_le_p(ram_ptr + addr, (uint32_t)val): Writes the 32-bit value (little-endian) to the calculated host address (ram_ptr + offset). This is the actual data replication happening on the host.
+            successful_writes is incremented.
+    QEMU Device: Release Lock (qemu_mutex_unlock(&s->lock)): The mutex is unlocked.
+    Return Path (Conceptual for a Write, Actual for a Read):
+        For a write, the cxl_switch_mem_write function completes.
+        If this were a read (mapped_mem[0] on the RHS of an assignment):
+            cxl_switch_mem_read would be called.
+            It would lock, find one healthy s->backing_mr[i], read data from it using ldl_le_p, unlock, and return the uint64_t data.
+            This data would propagate back through QEMU, the guest kernel, to the user-space program's mapped_mem[0].

--- a/qemu_share/Makefile
+++ b/qemu_share/Makefile
@@ -1,0 +1,11 @@
+# Makefile for the kernel module
+obj-m += cxl_switch_driver.o
+
+all:
+	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) modules
+
+
+clean:
+	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) clean
+
+

--- a/qemu_share/cxl_switch_driver.c
+++ b/qemu_share/cxl_switch_driver.c
@@ -1,24 +1,316 @@
+/**
+	This file implements the CXL switch driver for Linux kernel.
+
+	References: 
+		https://www.kernel.org/doc/html/next/PCI/pci.html
+		https://github.com/ysan/qemu-edu-driver/blob/main/driver/qemuedu.c
+		@author Jotham Wong
+*/
+
+#include "linux/cdev.h"
+#include "linux/device/class.h"
+#include "linux/err.h"
+#include "linux/fs.h"
+#include "linux/mm.h"
+#include "linux/mm_types.h"
+#include "linux/mod_devicetable.h"
+#include "linux/node.h"
+#include "linux/pci.h"
+#include "linux/slab.h"
+#include "linux/types.h"
 #include <linux/init.h>
 #include <linux/module.h>
 #include <linux/printk.h>
+
 
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("cs5250"); // Replace with your
 MODULE_DESCRIPTION("A sample kernel module");
 
-static int __init hello_init(void)
-{
-    printk(KERN_NOTICE "Hello World!\n");
-    pr_info("Hello, world!\n");
-    pr_debug("Greetings from %s.\n", THIS_MODULE->name);
+#define DRIVER_NAME "cxl_switch"
+#define DRIVER_VERSION "0.1"
+#define DEVICE_NAME "cxl_switch"
 
-    return 0;
+#define CXL_VENDOR_ID 0x1AF4
+#define CXL_DEVICE_ID 0x1337
+
+// Support just one device instance at a time
+#define MAX_DEVICES 1
+
+static int device_count = 0;
+
+/* Per-device data structure */
+struct cxl_switch_dev {
+	struct pci_dev *pdev;
+
+	void __iomem *bar0_kva; // kernel virtual address
+	resource_size_t bar0_start;
+	resource_size_t bar0_len;
+
+	dev_t devt; // major/minor number
+	struct cdev c_dev; // character device structure
+	struct class *dev_class; // For automatic /dev node creation
+};
+
+static struct cxl_switch_dev *cxl_switch_devs[MAX_DEVICES];
+
+/* File operations */
+
+static int cxl_switch_open(struct inode *inode, struct file *filp)
+{
+	struct cxl_switch_dev *dev;
+
+	dev = container_of(inode->i_cdev, struct cxl_switch_dev, c_dev);
+	filp->private_data = dev;
+
+	pr_info("%s: Opened device %s\n", DRIVER_NAME, pci_name(dev->pdev));
+	return 0;
 }
 
-static void __exit hello_exit(void)
+static int cxl_switch_release(struct inode *inode, struct file *filp)
 {
-    pr_info("Goodbye world.\n");
+	struct cxl_switch_dev *dev = filp->private_data;
+
+	pr_info("%s: Closed device %s\n", DRIVER_NAME, pci_name(dev->pdev));
+	return 0;
 }
 
-module_init(hello_init);
-module_exit(hello_exit);
+// Map device's BAR0 into user-space process's address space
+static int cxl_switch_mmap(struct file *filp, struct vm_area_struct *vma)
+{
+	unsigned long offset, phys, vsize, psize;
+	int ret;
+	struct cxl_switch_dev *dev = filp->private_data;
+	struct pci_dev *pdev = dev->pdev;
+	int bar_idx = 0;
+
+	offset = vma->vm_pgoff << PAGE_SHIFT;
+	// BAR Physical address
+	phys = pci_resource_start(pdev, bar_idx) + offset;
+	vsize = vma->vm_end - vma->vm_start;
+	psize = pci_resource_len(pdev, bar_idx);
+
+	pr_info("%s: mmap called for %s, offset=0x%lx, vsize=0x%lx, psize=0x%lx\n", 
+		DRIVER_NAME, pci_name(pdev), offset, vsize, psize);
+	
+	if (vsize > psize) {
+		pr_err("%s: mmap failed, requested size exceeds BAR size\n", DRIVER_NAME);
+		return -EINVAL;
+	}
+
+	// do not cache page
+	vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
+	// prevent touching page for swap in and swap out
+	vm_flags_set(vma, VM_IO | VM_DONTEXPAND | VM_DONTDUMP);
+	// make MMIO accessible to user-space
+	ret = io_remap_pfn_range(vma, vma->vm_start, phys >> PAGE_SHIFT, vsize, vma->vm_page_prot);
+	
+	if (ret) {
+		pr_err("%s: mmap failed, error=%d\n", DRIVER_NAME, ret);
+		return ret;
+	}
+
+	pr_info("%s: Mapped BAR0 region (offset 0x%lx, size 0x%lx) for %s to user space.\n",
+            DRIVER_NAME, offset, vsize, pci_name(dev->pdev));
+	return 0;
+}
+
+static const struct file_operations cxl_switch_fops = {
+	.owner = THIS_MODULE,
+	.open = cxl_switch_open,
+	.release = cxl_switch_release,
+	.mmap = cxl_switch_mmap,
+};
+
+/* PCI Driver */
+
+static int cxl_switch_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
+{
+	struct cxl_switch_dev *dev;
+	int ret;
+	int current_dev_idx = 0;
+
+	pr_info("%s: Probing PCI device %04x:%04x\n", DRIVER_NAME, pdev->vendor, pdev->device);
+
+	// We probably do not need to support more than one for our set up
+	// since each VM only connects to one device
+	// So we can simplify the development here
+	if (device_count >= MAX_DEVICES) {
+		pr_err("%s: Maximum device count reached\n", DRIVER_NAME);
+		return -ENODEV;
+	}
+
+	current_dev_idx = device_count;
+
+	dev = kzalloc(sizeof(struct cxl_switch_dev), GFP_KERNEL);
+	if (!dev) {
+		pr_err("%s: Failed to allocate memory for device\n", DRIVER_NAME);
+		return -ENOMEM;
+	}
+	dev->pdev = pdev;
+
+	// 1. Enable the PCI device
+	ret = pci_enable_device(pdev);
+	if (ret) {
+		pr_err("%s: Failed to enable PCI device, error=%d\n", DRIVER_NAME, ret);
+		kfree(dev);
+		return ret;
+	}
+
+	// 2. Request MMIO/IOP resources
+	
+	// 	BAR0 is data BAR in cxl-switch device atm
+	dev->bar0_start	= pci_resource_start(pdev, 0);
+	dev->bar0_len	= pci_resource_len(pdev, 0);
+	if (!dev->bar0_start || !dev->bar0_len) {
+		pr_err("%s: Failed to get BAR0 resource\n", DRIVER_NAME);
+		ret = -ENODEV;
+		goto err_disable_device;
+	}
+
+	// 	Request memory region for BAR0
+	ret = pci_request_region(pdev, 0, DRIVER_NAME);
+	if (ret) {
+		pr_err("%s: Failed to request BAR0 region, error=%d\n", DRIVER_NAME, ret);
+		goto err_disable_device;
+	}
+    	pr_info("%s: BAR0 mapped at guest_phys 0x%llx, len 0x%llx for %s.\n",
+		DRIVER_NAME, (unsigned long long)dev->bar0_start, (unsigned long long)dev->bar0_len, pci_name(pdev));
+
+	// 	Map the BAR0 to kernel virtual address space
+	dev->bar0_kva = pcim_iomap(pdev, 0, dev->bar0_len);
+	if (!dev->bar0_kva) {
+		pr_err("%s: Failed to map BAR0, error=%d\n", DRIVER_NAME, ret);
+		goto err_release_region;
+	}
+	pr_info("%s: BAR0 for %s mapped to kernel virtual address %p\n", DRIVER_NAME, pci_name(pdev), dev->bar0_kva);
+
+	// 3. Set DMA ... (not applicable for now?)
+	// 4. Allocate and init shared control data space (N/A?)
+	// 5. Access device configuration space (N/A?)
+	// 6. Register IRQ handler (N/A?)
+
+	// 7. Initialize character device to talk to cxl switch PCI device
+
+	ret = alloc_chrdev_region(&dev->devt, 0, 1, DEVICE_NAME);
+	if (ret < 0) {
+		pr_err("%s: Failed to allocate char device number, error=%d\n", DRIVER_NAME, ret);
+		goto err_iounmap_bar0;
+	}
+
+	cdev_init(&dev->c_dev, &cxl_switch_fops);
+	dev->c_dev.owner = THIS_MODULE;
+	ret = cdev_add(&dev->c_dev, dev->devt, 1);
+	if (ret) {
+		pr_err("%s: Failed to add cdev, error=%d\n", DRIVER_NAME, ret);
+		goto err_unregister_char_dev;
+	}
+
+	dev->dev_class = class_create(DEVICE_NAME);
+	if (IS_ERR(dev->dev_class)) {
+		pr_err("%s: Failed to create class for %s, error=%ld\n", DRIVER_NAME, pci_name(dev->pdev), PTR_ERR(dev->dev_class));
+		ret = PTR_ERR(dev->dev_class);
+		goto err_cdev_del;
+	}
+
+	if (IS_ERR(device_create(dev->dev_class, &pdev->dev, dev->devt, NULL, "%s%d", DEVICE_NAME, current_dev_idx))) {
+		pr_err("%s: Failed to create device node for %s\n", DRIVER_NAME, pci_name(dev->pdev));
+		ret = -ENODEV;
+		goto err_class_destroy;
+	}
+
+	pci_set_drvdata(pdev, dev);
+	cxl_switch_devs[current_dev_idx] = dev;
+	device_count++;
+	pr_info("%s: Device %s registered with major %d, minor %d\n", DRIVER_NAME, pci_name(dev->pdev), MAJOR(dev->devt), MINOR(dev->devt));
+	return 0;
+
+err_class_destroy:
+	class_destroy(dev->dev_class);
+err_cdev_del:
+	cdev_del(&dev->c_dev);
+err_unregister_char_dev:
+	unregister_chrdev_region(dev->devt, 1);
+err_iounmap_bar0:
+	if (dev->bar0_kva) {
+		pcim_iounmap(pdev, dev->bar0_kva);
+	}
+err_release_region:
+	pci_release_region(pdev, 0);
+err_disable_device:
+	pci_disable_device(pdev);
+	kfree(dev);
+	return ret;
+}
+
+static void cxl_switch_pci_remove(struct pci_dev *pdev)
+{
+	struct cxl_switch_dev *dev = pci_get_drvdata(pdev);
+	int i;
+
+	pr_info("%s: Removing PCI device %s (VID: %04x, DID: %04x)\n", DRIVER_NAME, pci_name(pdev), pdev->vendor, pdev->device);
+
+	if (!dev) {
+		pr_err("%s: Device data not found for %s\n", DRIVER_NAME, pci_name(pdev));
+		return;
+	}
+
+	// Cleanup in reverse order of probe
+	device_destroy(dev->dev_class, dev->devt);
+	class_destroy(dev->dev_class);
+	cdev_del(&dev->c_dev);
+	unregister_chrdev_region(dev->devt, 1);
+
+	if (dev->bar0_kva) {
+		pcim_iounmap(pdev, dev->bar0_kva);
+	}
+	pci_release_region(pdev, 0);
+	pci_disable_device(pdev);
+	// Primitive tracking
+	for (i = 0; i < MAX_DEVICES; ++i) {
+		if (cxl_switch_devs[i] == dev) {
+			cxl_switch_devs[i] = NULL;
+            		device_count--;
+            		break;
+        	}
+   	}
+	kfree(dev);
+	pci_set_drvdata(pdev, NULL);
+}
+
+// PCI ID Table: What hardware is supported
+static const struct pci_device_id cxl_switch_ids[] = {
+	{ PCI_DEVICE(CXL_VENDOR_ID, CXL_DEVICE_ID) },
+	{ 0, }
+};
+// Exposes IDs to user-space and module loading tools
+MODULE_DEVICE_TABLE(pci, cxl_switch_ids);
+
+// PCI driver structure
+static struct pci_driver cxl_switch_driver = {
+	.name = DRIVER_NAME,
+	.id_table = cxl_switch_ids,
+	.probe = cxl_switch_pci_probe,
+	.remove = cxl_switch_pci_remove,
+};
+
+/* Module init/exit */
+
+static int __init cxl_switch_init_module(void)
+{
+	pr_info("%s: Initializing CXL Switch Driver\n", DRIVER_NAME);
+	return pci_register_driver(&cxl_switch_driver);
+}
+
+static void __exit cxl_switch_exit_module(void)
+{
+	pr_info("%s: Exiting CXL Switch Driver\n", DRIVER_NAME);
+	pci_unregister_driver(&cxl_switch_driver);	
+}
+
+module_init(cxl_switch_init_module);
+module_exit(cxl_switch_exit_module);
+
+MODULE_LICENSE("GPL v2"); // SPDX-License-Identifier requires "GPL v2" or similar for GPL-2.0
+MODULE_AUTHOR("Jotham Wong");
+MODULE_DESCRIPTION("Basic Linux driver for CXL Replicated Switch (BAR2 mmap)");

--- a/qemu_share/cxl_switch_driver.c
+++ b/qemu_share/cxl_switch_driver.c
@@ -1,0 +1,24 @@
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/printk.h>
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("cs5250"); // Replace with your
+MODULE_DESCRIPTION("A sample kernel module");
+
+static int __init hello_init(void)
+{
+    printk(KERN_NOTICE "Hello World!\n");
+    pr_info("Hello, world!\n");
+    pr_debug("Greetings from %s.\n", THIS_MODULE->name);
+
+    return 0;
+}
+
+static void __exit hello_exit(void)
+{
+    pr_info("Goodbye world.\n");
+}
+
+module_init(hello_init);
+module_exit(hello_exit);

--- a/qemu_share/test_cxl_mmap.c
+++ b/qemu_share/test_cxl_mmap.c
@@ -1,0 +1,58 @@
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#define DEVICE_PATH "/dev/cxl_switch0"
+#define MAP_SIZE (256 * 1024 * 1024) // Should match replicated_mem_size
+
+int main() {
+  int fd;
+  volatile uint32_t *mapped_mem; // Use volatile for device memory
+
+  fd = open(DEVICE_PATH, O_RDWR | O_SYNC);
+  if (fd < 0) {
+    perror("Failed to open device");
+    return 1;
+  }
+
+  // Map the entire BAR0 region
+  mapped_mem = mmap(NULL, MAP_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  if (mapped_mem == MAP_FAILED) {
+    perror("Failed to mmap device");
+    close(fd);
+    return 1;
+  }
+
+  printf("Device mmap'd successfully. Pointer: %p\n", mapped_mem);
+
+  // Example: Write a value, then read it back
+  printf("Initial value at offset 0: 0x%08x\n", mapped_mem[0]);
+  mapped_mem[0] = 0xAABBCCDD;
+  printf("Wrote 0xAABBCCDD to offset 0.\n");
+  printf("Value read back from offset 0: 0x%08x\n", mapped_mem[0]);
+
+  // Example: Write to a different offset
+  // Ensure this offset is within MAP_SIZE
+  size_t offset_dw = 1024; // 1024 * 4 bytes = 4KB offset
+  if ((offset_dw * sizeof(uint32_t)) < MAP_SIZE) {
+    mapped_mem[offset_dw] = 0x12345678;
+    printf("Wrote 0x12345678 to dword offset %zu.\n", offset_dw);
+    printf("Value read back from dword offset %zu: 0x%08x\n", offset_dw,
+           mapped_mem[offset_dw]);
+  }
+
+  // Check the host replica files after these writes
+  printf("Check the host replica files now for the written values.\n");
+  printf("Press Enter to unmap and exit...\n");
+  getchar();
+
+  if (munmap((void *)mapped_mem, MAP_SIZE) == -1) {
+    perror("Failed to munmap");
+  }
+  close(fd);
+  return 0;
+}


### PR DESCRIPTION
This PR adds the following:
- CXL Switch QEMU Device
- Device driver (kernel module)
- Userspace program

This changes are likely to be deprecated almost immediately due to oversight on my end on how concurrent VMs would interact with it, see #1.
Still going to merge into main, as it is likely that these changes will remain educational for future me.