### PR TITLE
Rework bars

### DIFF
--- a/jotham_notes.md
+++ b/jotham_notes.md
@@ -35,17 +35,24 @@ This will allow true concurrent server without need for cache coherence since
 each client/server writes to a dedicated region, and exclusive access each time
 due to RPC logic.
 
+Writes/reads are sent to BAR, intercepted by Device driver, and tagged with 
+corresponding channel id based off device mapping. so device driver must be
+updated of bar->channel mapping and channel->bar mapping.
+
 Ok, now we have logical understanding of why we need to do this, 
 we go thru the program flow.
 
 Client requests for shared channel using `DiancieClient::request_channel`
-Client uses `QEMUCXLConnector::set_memory_window` to ioctl to the actual kernel
-module to retrieve which BAR client can use. Client will then map the bar.
+Client uses `QEMUCXLConnector::set_memory_window` to the QEMU device to retrieve 
+which BAR client can use. Client will then map the bar.
 
 Server receives shared channel. Server uses `QEMUCXLConnector::set_memory_window`
-to ioctl to actual kernel module to retrieve which BAR server can use. Server
+to the QEMU device to retrieve which BAR server can use. Server
 will map the bar. Server needs to service multiple clients, so must map to array.
 
+Ok, I just learnt that a PCIe device can only have 6 32 bit BARs at once, and 
+a 64 bit BAR (which is what we use for data) essentially uses 2 32 bit BARs at 
+once. The 32 bits of both BARs are combined to form top/bottom of the 64 bits.
 
 ## 16 June
 


### PR DESCRIPTION
Ok: this failed.
I did not realise that a PCIe device can only have 6 32 bit BARs, and using a 64 bit BAR like I was for data, means that you lose 1 BAR. so that means we are fundamentally limited to just 2 64 bit BARS for data, and there is kinda no point then. I will just merge my plan into main, for future notes. And push the rest into this branch and continue work on debugging the double param.

For future reference:
```
[  103.300195] cxl_switch_client: BAR2 Connection mapped at guest_phys 0xc40000000, len 0x10000000 for 0000:00:04.0.
[  103.300196] cxl_switch_client: BAR2 Connection available at guest_phys 0xc40000000, len 0x10000000 for 0000:00:04.0.
[  103.300198] cxl_switch_client: Failed to get BAR3 Connection resource
[  103.301363] cxl_switch_client: Failed to probe BAR3 Connection, error=-19
[  103.301365] cxl_switch_client: BAR4 Connection mapped at guest_phys 0xc50000000, len 0x10000000 for 0000:00:04.0.
[  103.301366] cxl_switch_client: BAR4 Connection available at guest_phys 0xc50000000, len 0x10000000 for 0000:00:04.0.
[  103.301367] cxl_switch_client: Failed to get BAR5 Connection resource
[  103.302512] cxl_switch_client: Failed to probe BAR5 Connection, error=-19
```

This was the error that occurs, explained above.