### PR TITLE
15 fix bug with memory access and enable concurrent access

### DIFF
--- a/qemu_share/clientlib/rpcclient.hpp
+++ b/qemu_share/clientlib/rpcclient.hpp
@@ -177,7 +177,7 @@ public:
     // Wait for server's response: This is blocking as we only adopt sync model
     while (server_queue_[server_queue_offset_].get_flag() == 0) {
       // TODO: Optimize polling
-      std::this_thread::sleep_for(std::chrono::microseconds(100));
+      std::this_thread::sleep_for(std::chrono::microseconds(100000));
     }
     std::cout << "Server processing complete" << std::endl;
 

--- a/qemu_share/fabricmanager/cxl_fm.cpp
+++ b/qemu_share/fabricmanager/cxl_fm.cpp
@@ -178,6 +178,7 @@ void CXLFabricManager::handle_read_mem_req(int qemu_vm_fd, const cxl_ipc_read_re
   //            ", channel_id: " + std::to_string(req.channel_id) + 
   //            ", addr: " + std::to_string(req.addr) +
   //            ", size: " + std::to_string(req.size));
+
   
   // Early terminate from a nonsensical request
   if ((req.addr + req.size) > config_.replica_mem_size) {
@@ -224,6 +225,13 @@ void CXLFabricManager::handle_read_mem_req(int qemu_vm_fd, const cxl_ipc_read_re
       //                         the CXLMemDevice
       // We handle the check within the read_data and catch any errors
       uint64_t actual_offset = req.addr + allocated_region.offset;
+
+
+      std::cout << "Reading at actual offset " << actual_offset 
+        << ", allocated region offset " << allocated_region.offset
+        << ", request offset " << req.addr
+        << " from QEMU VM FD " << qemu_vm_fd
+        << std::endl;
       // Temp buffer to hold data as max read is 8 bytes
       uint8_t tmp_buffer[8];
       resp.value = 0; // init to all 0s to ensure upper bytes are zero-ed

--- a/qemu_share/fabricmanager/memdevice.cpp
+++ b/qemu_share/fabricmanager/memdevice.cpp
@@ -13,6 +13,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <utility>
+#include <vector>
 
 namespace cxl_fm {
 

--- a/qemu_share/fabricmanager/memdevice.hpp
+++ b/qemu_share/fabricmanager/memdevice.hpp
@@ -6,7 +6,7 @@
 #include <optional>
 #include <string>
 #include "../includes/cxl_switch_ipc.h"
-
+#include <vector>
 namespace cxl_fm {
 /**
   Represents a CXL Memory Device. At the moment, it is really just a 

--- a/qemu_share/includes/qemu_cxl_connector.hpp
+++ b/qemu_share/includes/qemu_cxl_connector.hpp
@@ -56,7 +56,7 @@ private:
   static constexpr off_t BAR2_MMAP_OFFSET = 2 * 4096; // MMAP_OFFSET_PGOFF_BAR2
   static constexpr size_t DEFAULT_BAR0_SIZE = 4096;
   static constexpr size_t DEFAULT_BAR1_SIZE = 4096;
-  static constexpr size_t DEFAULT_BAR2_SIZE = 256 * 1024 * 1024;
+  static constexpr size_t DEFAULT_BAR2_SIZE = 1024 * 1024 * 1024;
 
 protected:
   // TODO: Make these private

--- a/qemu_share/includes/test_interface.hpp
+++ b/qemu_share/includes/test_interface.hpp
@@ -2,9 +2,11 @@
 #define TEST_RPC_INTERFACE_HPP
 
 #include "rpc_interface.hpp"
+#include <cstdint>
 
 using namespace diancie;
 
+// Struct test
 struct Person {
   int age;
   int salary; // avoid double for now
@@ -13,14 +15,11 @@ struct Person {
 
 enum class TestServiceFunctions : uint64_t {
   ADD,
-  AVERAGE,
   MULTIPLY,
-  // MULTIPLY_DOUBLE,
   PERSON,
 };
 
 DEFINE_DIANCIE_FUNCTION(TestServiceFunctions, ADD, int, int, int)
-DEFINE_DIANCIE_FUNCTION(TestServiceFunctions, AVERAGE, double, int, int)
 DEFINE_DIANCIE_FUNCTION(TestServiceFunctions, MULTIPLY, int, int, int)
 // DEFINE_DIANCIE_FUNCTION(TestServiceFunctions, MULTIPLY_DOUBLE, double, double, double)
 DEFINE_DIANCIE_FUNCTION(TestServiceFunctions, PERSON, Person, Person, Person)

--- a/qemu_share/kernelmodule/cxl_switch_driver.c
+++ b/qemu_share/kernelmodule/cxl_switch_driver.c
@@ -310,7 +310,7 @@ static irqreturn_t cxl_switch_client_isr(int irq, void *dev_id) {
     pr_info("%s: Close channel notification received.\n", DRIVER_NAME);
     if (dev->eventfd_notify_ctx) {
       eventfd_signal(dev->eventfd_notify_ctx);
-      pr_info("%s: Signaled eventfd for new client notification.\n", DRIVER_NAME);
+      pr_info("%s: Signaled eventfd for close channel notification.\n", DRIVER_NAME);
     } else {
       pr_info("%s: No eventfd context for new client notifications, skipping signal.\n", DRIVER_NAME);
     }

--- a/qemu_share/test/Makefile
+++ b/qemu_share/test/Makefile
@@ -1,0 +1,26 @@
+CXX = g++
+CXXFLAGS = -std=c++17 -O0 -g
+INCLUDES = -I../includes
+
+# Source files
+SERVER_SRCS = test_server.cpp ../includes/*.cpp
+CLIENT_SRCS = test_client.cpp ../includes/*.cpp
+
+# Libraries
+LIBS = -lpthread
+
+.PHONY: all clean
+
+all: test_server test_client
+
+test_server: $(SERVER_SRCS)
+	@echo "Building test server..."
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -I../serverlib -I. $(SERVER_SRCS) $(LIBS) -o $@
+
+test_client: $(CLIENT_SRCS)
+	@echo "Building test client..."
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -I../clientlib -I. $(CLIENT_SRCS) $(LIBS) -o $@
+
+clean:
+	@echo "Cleaning..."
+	rm -f test_server test_client

--- a/qemu_share/test/test_client.cpp
+++ b/qemu_share/test/test_client.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <random>
 #include <thread>
+#include <unistd.h>
 
 using namespace diancie;
 
@@ -17,7 +18,7 @@ void test_basic_arithmetic(DiancieClient<TestServiceFunctions>& client) {
     std::uniform_int_distribution<int> int_dist(1, 1000);
 
     try {
-        int num_add_iterations = 1;
+        int num_add_iterations = 10;
         for (int i = 0; i < num_add_iterations; ++i) {
             int a = int_dist(gen);
             int b = int_dist(gen);
@@ -27,9 +28,11 @@ void test_basic_arithmetic(DiancieClient<TestServiceFunctions>& client) {
             std::cout << " a " << a << " b " << b << std::endl;
             int result = client.call<TestServiceFunctions::ADD>(a, b);
             std::cout << "Client: " << a << " + " << b << " = " << result << std::endl;
+
             
             // Check if the result is as expected
             assert(result == expected_result);
+            sleep(1);
         }
 
         int num_multiply_iterations = 10;
@@ -43,6 +46,7 @@ void test_basic_arithmetic(DiancieClient<TestServiceFunctions>& client) {
             std::cout << "Client: " << a << " * " << b << " = " << result << std::endl;
 
             assert(result == expected_result);
+            sleep(1);
             
             // Check if the result is as expected with small error bound
             // assert(std::abs(result - expected_result) < 0.001);

--- a/qemu_share/test/test_client.cpp
+++ b/qemu_share/test/test_client.cpp
@@ -17,7 +17,7 @@ void test_basic_arithmetic(DiancieClient<TestServiceFunctions>& client) {
     std::uniform_int_distribution<int> int_dist(1, 1000);
 
     try {
-        int num_add_iterations = 10;
+        int num_add_iterations = 1;
         for (int i = 0; i < num_add_iterations; ++i) {
             int a = int_dist(gen);
             int b = int_dist(gen);

--- a/qemu_share/test/test_server.cpp
+++ b/qemu_share/test/test_server.cpp
@@ -13,12 +13,14 @@ using namespace diancie;
 int add_numbers_impl(int &a, int &b) {
   std::cout << "Server: Adding " << a << " + " << b << " (zero-copy)"
             << std::endl;
+  std::cout << "a is at address " << &a << ", b is at address " << &b
+            << std::endl;
   int result = a + b;
   std::cout << "Server: Result = " << result << std::endl;
   return result;
 }
 
-int multiply_doubles_impl(int &a, int &b) {
+int multiply_impl(int &a, int &b) {
   std::cout << "Server: Multiplying " << a << " * " << b << " (zero-copy)"
             << std::endl;
   int result = a * b;
@@ -57,8 +59,7 @@ int main(int argc, char *argv[]) {
     std::cout << "\n=== Registering RPC Functions ===" << std::endl;
 
     server.register_rpc_function<TestServiceFunctions::ADD>(add_numbers_impl);
-    server.register_rpc_function<TestServiceFunctions::MULTIPLY>(
-        multiply_doubles_impl);
+    server.register_rpc_function<TestServiceFunctions::MULTIPLY>(multiply_impl);
     server.register_rpc_function<TestServiceFunctions::PERSON>(process_person);
 
     std::cout << "\n=== Registering Service ===" << std::endl;


### PR DESCRIPTION
This PR does two things:

1. It fixed up the memory access for each channel. I was incorrectly updating the BAR 2 base in the device, when I should really have not been touching it, but updating the channel struct that the QEMU device maintains in `channel_map` and its corresponding functions. Essentially:

MMIO Region start
_________________
MMIO Sub Region 1
_________________
MMIO Sub Region 2
_________________

the mmio region is divided into sub regions with the channel. The server reads and writes at each offset, then subtracts the offset from the channel map to get the true offset and sends it alongside the FM which routes it correctly.

However, at the moment, I am using a naive, simple method of max allocation to get the next MMIO sub region. Because all channels are the same size, I can actually just store an array of offsets and fix it up. So I will do that in a next TODO.

2. Thanks to the fix above, the server can now actually concurrently service multiple clients. This was verified manually by running 2 client instances at once. But this was not stress tested. (1) directly enables concurrency for the RPC server, so nothing else to add here.
