### PR TITLE
feat: Handle wraparound and optimize space

### DIFF
--- a/qemu_share/includes/a_cxl_connector.hpp
+++ b/qemu_share/includes/a_cxl_connector.hpp
@@ -114,16 +114,15 @@ public:
   // Each queue entry is 64 bits, or 8 bytes.
   static constexpr int NUM_QUEUE_ENTRIES = 128;
   // 64 bits can identify 2**64 queue entries
-  static constexpr uint64_t CLIENT_QUEUE_POSITION = 0; // Position for client queue
-  static constexpr uint64_t SERVER_QUEUE_POSITION = 8; // Position for server queue
+  static constexpr uint64_t QUEUE_POSITION = 0; // Position for client/server queue
 
-  static constexpr uint64_t CLIENT_QUEUE_OFFSET = 16; // after server queue
+  static constexpr uint64_t CLIENT_QUEUE_OFFSET = 8; // after queue position
   static constexpr size_t   CLIENT_QUEUE_SIZE   = NUM_QUEUE_ENTRIES * 8;
 
-  static constexpr uint64_t SERVER_QUEUE_OFFSET = 16 + CLIENT_QUEUE_SIZE;
+  static constexpr uint64_t SERVER_QUEUE_OFFSET = CLIENT_QUEUE_OFFSET + CLIENT_QUEUE_SIZE;
   static constexpr uint64_t SERVER_QUEUE_SIZE   = NUM_QUEUE_ENTRIES * 8;
 
-  static constexpr uint64_t DATA_AREA_OFFSET    = 16 + CLIENT_QUEUE_SIZE + SERVER_QUEUE_SIZE;
+  static constexpr uint64_t DATA_AREA_OFFSET    = CLIENT_QUEUE_OFFSET + CLIENT_QUEUE_SIZE + SERVER_QUEUE_SIZE;
 
   size_t size;
   uint64_t DATA_AREA_SIZE    = size - CLIENT_QUEUE_SIZE + SERVER_QUEUE_SIZE;

--- a/qemu_share/test/test_client.cpp
+++ b/qemu_share/test/test_client.cpp
@@ -18,7 +18,7 @@ void test_basic_arithmetic(DiancieClient<TestServiceFunctions>& client) {
     std::uniform_int_distribution<int> int_dist(1, 1000);
 
     try {
-        int num_add_iterations = 10;
+        int num_add_iterations = 128;
         for (int i = 0; i < num_add_iterations; ++i) {
             int a = int_dist(gen);
             int b = int_dist(gen);
@@ -32,10 +32,10 @@ void test_basic_arithmetic(DiancieClient<TestServiceFunctions>& client) {
             
             // Check if the result is as expected
             assert(result == expected_result);
-            sleep(1);
+            // sleep(1);
         }
 
-        int num_multiply_iterations = 10;
+        int num_multiply_iterations = 128;
         for (int i = 0; i < num_multiply_iterations; ++i) {
             int a = int_dist(gen);
             int b = int_dist(gen);
@@ -46,7 +46,7 @@ void test_basic_arithmetic(DiancieClient<TestServiceFunctions>& client) {
             std::cout << "Client: " << a << " * " << b << " = " << result << std::endl;
 
             assert(result == expected_result);
-            sleep(1);
+            // sleep(1);
             
             // Check if the result is as expected with small error bound
             // assert(std::abs(result - expected_result) < 0.001);


### PR DESCRIPTION
We handle wrap around by making use of the generational counter idea and interpret the flag differently depending on the offset.

We also remove the need for client/server queue offsets as they are actually always the same value at all times, so we can make use of just one offset both in code and in the shm offset.

The impl is tested by making the test case use 256 RPC calls. This will wrap around, and the test case succeeds only if the impl was correct, which it is.