### PR TITLE
18 add userspace shmalloc

### DIFF
--- a/hw/misc/cxl-switch-client.c
+++ b/hw/misc/cxl-switch-client.c
@@ -438,12 +438,22 @@ static void bar1_control_write(void *opaque, hwaddr addr, uint64_t val, unsigned
                     tmp_status = set_window_resp.status;
                     expected_server_resp_len = 0; // no server payload
                     break;
+                }
+                case CXL_MSG_TYPE_RPC_SERVER_CONNECTED: {
+                    // Simple route to FM
+                    cxl_ipc_rpc_server_connected_t *server_connected_resp = (cxl_ipc_rpc_server_connected_t *)s->bar0_mailbox;
+                    send(s->server_fd, server_connected_resp, sizeof(*server_connected_resp), 0);
+                    // No need for a response
+                    ipc_ret = 0;
+                    tmp_status = CXL_IPC_STATUS_OK;
+                    expected_server_resp_len = 0;
+                    break;
+                }
                 default:
                     CXL_SWITCH_DPRINTF("Error: Unknown command type 0x%02x.\n", cmd_type);
                     qemu_mutex_lock(&s->lock);
                     s->command_status_reg = CMD_STATUS_ERROR_INTERNAL;
                     goto cmd_done_unlock_no_msi;
-            }
         }
         
         qemu_mutex_lock(&s->lock);

--- a/hw/misc/cxl-switch-client.c
+++ b/hw/misc/cxl-switch-client.c
@@ -422,12 +422,11 @@ static void bar1_control_write(void *opaque, hwaddr addr, uint64_t val, unsigned
             
                     CXL_SWITCH_DPRINTF("Info: Handling RPC_SET_BAR2_WINDOW request. Offset=0x%"PRIx64", Size=0x%"PRIx64"\n",
                                     set_window_req->offset, set_window_req->size);
-                    
-                    if (set_window_req->size <= s->bar2_data_size && (set_window_req->offset + set_window_req->size) <= s->total_pool_size) {
+
+                    if (set_window_req->size <= s->bar2_data_size && ((set_window_req->offset + set_window_req->size) <= s->total_pool_size) && register_new_channel(set_window_req->offset, set_window_req->size, set_window_req->channel_id, s)) {
                         set_window_resp.status = CXL_IPC_STATUS_OK;
-                        register_new_channel(set_window_req->offset, set_window_req->size, set_window_req->channel_id, s);
                         CXL_SWITCH_DPRINTF("Info: BAR2 window set successfully. Offset=0x%"PRIx64", Size=0x%"PRIx64"\n",
-                                        s->bar2_data_window_offset, s->bar2_data_window_size);
+                            s->bar2_data_window_offset, s->bar2_data_window_size);
                     } else {
                         set_window_resp.status = CXL_IPC_STATUS_BAR2_FAILED;
                         CXL_SWITCH_DPRINTF("Error: Invalid BAR2 window configuration. Offset=0x%"PRIx64", Size=0x%"PRIx64"\n",

--- a/include/hw/misc/cxl_switch_ipc.h
+++ b/include/hw/misc/cxl_switch_ipc.h
@@ -43,6 +43,8 @@ typedef enum {
     CXL_MSG_TYPE_RPC_SET_BAR2_WINDOW_RESP = 0x31,
     // Generic error for mgmt
     CXL_MSG_TYPE_RPC_MGMT_ERROR_RESP = 0x3F,
+    // cxl_ipc_rpc_server_connected_t
+    CXL_MSG_TYPE_RPC_SERVER_CONNECTED = 0x40, // Server -> QEMU Device
 } cxl_ipc_rpc_mgmt_msg_type_t;
 
 // Admin message types (Host Tool <-> CXL Server)
@@ -194,6 +196,14 @@ typedef struct {
     char client_instance_id[MAX_INSTANCE_ID_LEN];
     char service_name[MAX_SERVICE_NAME_LEN];
 } cxl_ipc_rpc_new_client_notify_t;
+
+// CXL_MSG_TYPE_RPC_SERVER_CONNECTED
+// FM asks server if it can service a new client
+// Server replies with this
+typedef struct {
+    uint8_t type;
+    uint8_t status;
+} cxl_ipc_rpc_server_connected_t;
 
 // CXL_MSG_TYPE_RPC_CLOSE_CHANNEL_NOTIFY
 // A channel is forced to be closed due to other party

--- a/qemu_share/fabricmanager/cxl_fm.cpp
+++ b/qemu_share/fabricmanager/cxl_fm.cpp
@@ -47,6 +47,9 @@ namespace cxl_fm {
 #define CXL_FM_LOG_P(msg, val)
 #endif
 
+static constexpr uint32_t MEGABYTE = 1024 * 1024; 
+static constexpr uint32_t GIGABYTE = 1024 * MEGABYTE;
+
 // --- Event management ---
 
 //  --- Main Request handlers ---
@@ -373,7 +376,7 @@ void CXLFabricManager::handle_rpc_request_channel_req(int qemu_client_fd, const 
   //       an issue.
   std::vector<AllocatedRegionInfo> allocated_regions;
 
-  uint32_t requested_size = (256 * 1024 * 1024); // 256 MB
+  uint32_t requested_size = (1 * GIGABYTE);
   
   int num_allocated_replicas = 0;
   for (size_t i = 0; i < mem_devices_.size() && num_allocated_replicas < NUM_REPLICAS; i++) {

--- a/qemu_share/fabricmanager/cxl_fm.cpp
+++ b/qemu_share/fabricmanager/cxl_fm.cpp
@@ -376,7 +376,7 @@ void CXLFabricManager::handle_rpc_request_channel_req(int qemu_client_fd, const 
   //       an issue.
   std::vector<AllocatedRegionInfo> allocated_regions;
 
-  uint32_t requested_size = (1 * GIGABYTE);
+  uint32_t requested_size = (256 * MEGABYTE);
   
   int num_allocated_replicas = 0;
   for (size_t i = 0; i < mem_devices_.size() && num_allocated_replicas < NUM_REPLICAS; i++) {

--- a/qemu_share/includes/a_cxl_connector.hpp
+++ b/qemu_share/includes/a_cxl_connector.hpp
@@ -125,7 +125,7 @@ public:
   static constexpr uint64_t DATA_AREA_OFFSET    = CLIENT_QUEUE_OFFSET + CLIENT_QUEUE_SIZE + SERVER_QUEUE_SIZE;
 
   size_t size;
-  uint64_t DATA_AREA_SIZE    = size - CLIENT_QUEUE_SIZE + SERVER_QUEUE_SIZE;
+  uint64_t DATA_AREA_SIZE    = size - CLIENT_QUEUE_SIZE - SERVER_QUEUE_SIZE;
 public:
   DiancieHeap() = default;
   DiancieHeap(size_t size);

--- a/qemu_share/includes/cxl_ptr.hpp
+++ b/qemu_share/includes/cxl_ptr.hpp
@@ -1,0 +1,118 @@
+#ifndef DIANCIE_GLOBAL_PTR_HPP
+#define DIANCIE_GLOBAL_PTR_HPP
+
+#include <cstdint>
+#include <stdexcept>
+namespace diancie {
+
+template <typename FunctionEnum> class DiancieClient;
+template <typename FunctionEnum> class DiancieServer;
+
+// Context for data_area for thread local usage
+class ShmContext {
+private:
+  inline static thread_local void *data_area_ = nullptr;
+
+public:
+  ShmContext() {data_area_ = nullptr;}
+  ShmContext(void *data_area) { data_area_ = data_area; }
+  static void *get_data_area() { return data_area_; }
+  static void set_data_area(void *data_area) { data_area_ = data_area; }
+};
+
+template <typename T> class global_ptr {
+private:
+  template <typename FunctionEnum> friend class DiancieClient;
+
+  uint64_t offset_;
+  size_t count_;
+
+  global_ptr(uint64_t offset, size_t count = 1)
+      : offset_(offset), count_(count) {}
+
+public:
+  global_ptr() : offset_(0), count_(0) {}
+
+  T *local() const {
+    void *data_area = ShmContext::get_data_area();
+    if (!data_area) {
+      return nullptr;
+    }
+    return reinterpret_cast<T *>(static_cast<char *>(data_area) + offset_);
+  }
+
+  T &operator*() const {
+    T *ptr = local();
+    if (!ptr)
+      throw std::runtime_error("Dereferencing null ptr");
+    return *ptr;
+  }
+
+  T *operator->() const {
+    T *ptr = local();
+    if (!ptr)
+      throw std::runtime_error("Dereferencing null ptr");
+    return ptr;
+  }
+
+  T &operator[](size_t index) const {
+    if (index >= count_)
+      throw std::out_of_range("index out of range");
+    T *ptr = local();
+    if (!ptr)
+      throw std::runtime_error("Dereferencing null ptr");
+    return ptr[index];
+  }
+
+  global_ptr operator+(size_t n) const {
+    if (n > count_)
+      throw std::out_of_range("global_ptr arithmetic out of range");
+    return global_ptr(offset_ + n * sizeof(T), count_ - n);
+  }
+
+  global_ptr operator-(size_t n) const {
+    return global_ptr(offset_ - n * sizeof(T), count_ + n);
+  }
+
+  global_ptr &operator++() {
+    if (count_ == 0)
+      throw std::out_of_range("global_ptr increment out of range");
+    offset_ += sizeof(T);
+    count_--;
+    return *this;
+  }
+
+  global_ptr &operator--() {
+    offset_ -= sizeof(T);
+    count_++;
+    return *this;
+  }
+
+  bool operator==(const global_ptr& other) const {
+    return offset_ == other.offset_;
+  }
+    
+  bool operator!=(const global_ptr& other) const {
+    return offset_ != other.offset_;
+  }
+
+  // Transparent conversions
+  operator T&() const { return *local(); }           // For reference parameters
+  operator T*() const { return local(); }            // For pointer parameters  
+  operator uint64_t() const { return offset_; }      // For offset parameters
+
+  global_ptr& operator=(const T& value) {
+    *local() = value;
+    return *this;
+  }
+
+  uint64_t raw_offset() const { return offset_; }
+  size_t count() const { return count_; }
+  bool is_null() const { return offset_ == 0; }
+  bool is_local() const { return ShmContext::get_data_area() != nullptr; }
+   
+};
+
+} // namespace diancie
+
+#endif

--- a/qemu_share/includes/cxl_ptr.hpp
+++ b/qemu_share/includes/cxl_ptr.hpp
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <stdexcept>
+#include <iostream>
 namespace diancie {
 
 template <typename FunctionEnum> class DiancieClient;
@@ -35,6 +36,7 @@ public:
 
   T *local() const {
     void *data_area = ShmContext::get_data_area();
+    std::cout << "Dereferencing from data area " << data_area << std::endl;
     if (!data_area) {
       return nullptr;
     }

--- a/qemu_share/includes/cxl_ptr.hpp
+++ b/qemu_share/includes/cxl_ptr.hpp
@@ -24,16 +24,16 @@ public:
 template <typename T> class global_ptr {
 private:
   template <typename FunctionEnum> friend class DiancieClient;
-
+  
   uint64_t offset_;
   size_t count_;
-
+  
   global_ptr(uint64_t offset, size_t count = 1)
-      : offset_(offset), count_(count) {}
-
+  : offset_(offset), count_(count) {}
+  
 public:
   global_ptr() : offset_(0), count_(0) {}
-
+  
   T *local() const {
     void *data_area = ShmContext::get_data_area();
     std::cout << "Dereferencing from data area " << data_area << std::endl;

--- a/qemu_share/includes/cxl_switch_ipc.h
+++ b/qemu_share/includes/cxl_switch_ipc.h
@@ -43,6 +43,8 @@ typedef enum {
     CXL_MSG_TYPE_RPC_SET_BAR2_WINDOW_RESP = 0x31,
     // Generic error for mgmt
     CXL_MSG_TYPE_RPC_MGMT_ERROR_RESP = 0x3F,
+    // cxl_ipc_rpc_server_connected_t
+    CXL_MSG_TYPE_RPC_SERVER_CONNECTED = 0x40, // Server -> QEMU Device
 } cxl_ipc_rpc_mgmt_msg_type_t;
 
 // Admin message types (Host Tool <-> CXL Server)
@@ -163,7 +165,6 @@ typedef struct {
     uint8_t type;
     char service_name[MAX_SERVICE_NAME_LEN];
     char instance_id[MAX_INSTANCE_ID_LEN];
-    // TODO: Request size here
 } cxl_ipc_rpc_request_channel_req_t;
 
 typedef struct {
@@ -195,6 +196,14 @@ typedef struct {
     char client_instance_id[MAX_INSTANCE_ID_LEN];
     char service_name[MAX_SERVICE_NAME_LEN];
 } cxl_ipc_rpc_new_client_notify_t;
+
+// CXL_MSG_TYPE_RPC_SERVER_CONNECTED
+// FM asks server if it can service a new client
+// Server replies with this
+typedef struct {
+    uint8_t type;
+    uint8_t status;
+} cxl_ipc_rpc_server_connected_t;
 
 // CXL_MSG_TYPE_RPC_CLOSE_CHANNEL_NOTIFY
 // A channel is forced to be closed due to other party

--- a/qemu_share/includes/cxl_switch_ipc.h
+++ b/qemu_share/includes/cxl_switch_ipc.h
@@ -163,6 +163,7 @@ typedef struct {
     uint8_t type;
     char service_name[MAX_SERVICE_NAME_LEN];
     char instance_id[MAX_INSTANCE_ID_LEN];
+    // TODO: Request size here
 } cxl_ipc_rpc_request_channel_req_t;
 
 typedef struct {

--- a/qemu_share/includes/qemu_cxl_connector.hpp
+++ b/qemu_share/includes/qemu_cxl_connector.hpp
@@ -56,7 +56,7 @@ private:
   static constexpr off_t BAR2_MMAP_OFFSET = 2 * 4096; // MMAP_OFFSET_PGOFF_BAR2
   static constexpr size_t DEFAULT_BAR0_SIZE = 4096;
   static constexpr size_t DEFAULT_BAR1_SIZE = 4096;
-  static constexpr size_t DEFAULT_BAR2_SIZE = 1024 * 1024 * 1024;
+  static constexpr size_t DEFAULT_BAR2_SIZE = 1024 * 1024 * 1024; // 1GB
 
 protected:
   // TODO: Make these private

--- a/qemu_share/test/test_copy_client.cpp
+++ b/qemu_share/test/test_copy_client.cpp
@@ -51,6 +51,37 @@ void test_basic_arithmetic(DiancieClient<TestCopyFunctions>& client) {
     }
 }
 
+void test_basic_shm(DiancieClient<TestCopyFunctions>& client) {
+    std::cout << "\n=== Testing Shared Memory Operations ===" << std::endl;
+
+    try {
+        auto person = client.shm_new_<tracked_person>();
+        person->get().age = 25;
+        person->get().salary = 100;
+        person->get().kill_count = 0;
+
+        std::cout << "Created person on shm at " << &person << std::endl;
+
+        client.call<TestCopyFunctions::PROCESS_PERSON>(person);
+        
+        assert(person->get().age == 26);
+        assert(person->get().salary == 200);
+        assert(person->get().kill_count == 1);
+
+        person->printStats();
+
+        std::cout << "Referred person on shm at " << &person << std::endl;
+
+        std::cout << "✓ Shared memory operations tests passed!" << std::endl;
+        
+    } catch (const std::exception& e) {
+        std::cerr << "✗ Shared memory operations test failed: " << e.what() << std::endl;
+        throw;
+    }
+}
+
+
+
 int main(int argc, char* argv[]) {
     try {
         const std::string device_path = "/dev/cxl_switch_client0";
@@ -69,6 +100,7 @@ int main(int argc, char* argv[]) {
         
         // Run test suite
         test_basic_arithmetic(client);
+        test_basic_shm(client);
         
         std::cout << "\n=== All Tests Passed! ===" << std::endl;
         

--- a/qemu_share/test/test_copy_client.cpp
+++ b/qemu_share/test/test_copy_client.cpp
@@ -53,24 +53,34 @@ void test_basic_arithmetic(DiancieClient<TestCopyFunctions>& client) {
 
 void test_basic_shm(DiancieClient<TestCopyFunctions>& client) {
     std::cout << "\n=== Testing Shared Memory Operations ===" << std::endl;
-
+    
     try {
-        auto person = client.shm_new_<tracked_person>();
-        person->get().age = 25;
-        person->get().salary = 100;
-        person->get().kill_count = 0;
-
-        std::cout << "Created person on shm at " << &person << std::endl;
-
-        client.call<TestCopyFunctions::PROCESS_PERSON>(person);
         
-        assert(person->get().age == 26);
-        assert(person->get().salary == 200);
-        assert(person->get().kill_count == 1);
+        std::cout << "\n=== Testing shm person ===" << std::endl;
 
-        person->printStats();
+        auto shm_person = client.shm_new_<Person>();
+        shm_person->age = 25;
+        shm_person->salary = 100;
+        shm_person->kill_count = 0;
 
-        std::cout << "Referred person on shm at " << &person << std::endl;
+        std::cout << "Created person on shm at " << &shm_person << std::endl;
+
+        client.call<TestCopyFunctions::PROCESS_SHM_PERSON>(shm_person);
+        
+        assert(shm_person->age == 26);
+        assert(shm_person->salary == 200);
+        assert(shm_person->kill_count == 1);
+
+        std::cout << "Referred person on shm at " << &shm_person << std::endl;
+        Person person{.age=25, .salary=100, .kill_count=0};
+        std::cout << "Created person at " << &person << std::endl;
+        person = client.call<TestCopyFunctions::PROCESS_PERSON>(person);
+
+        assert(person.age == 26);
+        assert(person.salary == 200);
+        assert(person.kill_count == 1);
+
+        std::cout << "\n=== Testing shm person ===" << std::endl;
 
         std::cout << "✓ Shared memory operations tests passed!" << std::endl;
         

--- a/qemu_share/test/test_copy_interface.hpp
+++ b/qemu_share/test/test_copy_interface.hpp
@@ -3,6 +3,7 @@
 
 #include "../includes/counter_wrapper.hpp"
 #include "../includes/rpc_interface.hpp"
+#include "../includes/cxl_ptr.hpp"
 #include <cstdint>
 
 using namespace diancie;
@@ -12,14 +13,22 @@ struct Person {
   int age;
   int salary; // avoid double for now
   int kill_count;
+
+  friend std::ostream& operator<<(std::ostream& os, const Person& p) {
+    os << "Person{age: " << p.age << ", salary: " << p.salary << ", kill_count: " << p.kill_count << "}";
+    return os;
+  }
 };
 
 enum class TestCopyFunctions : uint64_t {
   ADD,
+  PROCESS_PERSON,
 };
 
 using tracked_int = diancie::CounterWrapper<int>;
+using tracked_person = diancie::CounterWrapper<Person>;
 
 DEFINE_DIANCIE_FUNCTION(TestCopyFunctions, ADD, tracked_int, tracked_int, tracked_int);
+DEFINE_DIANCIE_FUNCTION(TestCopyFunctions, PROCESS_PERSON, void, global_ptr<tracked_person>);
 
 #endif

--- a/qemu_share/test/test_copy_interface.hpp
+++ b/qemu_share/test/test_copy_interface.hpp
@@ -22,6 +22,7 @@ struct Person {
 
 enum class TestCopyFunctions : uint64_t {
   ADD,
+  PROCESS_SHM_PERSON,
   PROCESS_PERSON,
 };
 
@@ -29,6 +30,7 @@ using tracked_int = diancie::CounterWrapper<int>;
 using tracked_person = diancie::CounterWrapper<Person>;
 
 DEFINE_DIANCIE_FUNCTION(TestCopyFunctions, ADD, tracked_int, tracked_int, tracked_int);
-DEFINE_DIANCIE_FUNCTION(TestCopyFunctions, PROCESS_PERSON, void, global_ptr<tracked_person>);
+DEFINE_DIANCIE_FUNCTION(TestCopyFunctions, PROCESS_SHM_PERSON, void, global_ptr<Person>);
+DEFINE_DIANCIE_FUNCTION(TestCopyFunctions, PROCESS_PERSON, Person, Person);
 
 #endif

--- a/qemu_share/test/test_copy_server.cpp
+++ b/qemu_share/test/test_copy_server.cpp
@@ -1,6 +1,7 @@
 #include "./test_copy_interface.hpp"
 #include "../includes/counter_wrapper.hpp"
 #include "../serverlib/rpcserver.hpp"
+#include "../includes/cxl_ptr.hpp"
 #include <algorithm>
 #include <cmath>
 #include <cstring>
@@ -21,6 +22,14 @@ tracked_int add_impl(tracked_int &a, tracked_int &b) {
   return result;
 }
 
+void process_person(global_ptr<tracked_person> &person) {
+  std::cout << "Person addr is at " << &person->get() << std::endl;
+  person->get().age+=1;
+  person->get().salary+=100;
+  person->get().kill_count+=1;
+  person->printStats();
+}
+
 int main(int argc, char *argv[]) {
   try {
     const std::string device_path = "/dev/cxl_switch_client0";
@@ -33,6 +42,7 @@ int main(int argc, char *argv[]) {
     std::cout << "\n=== Registering RPC Functions ===" << std::endl;
 
     server.register_rpc_function<TestCopyFunctions::ADD>(add_impl);
+    server.register_rpc_function<TestCopyFunctions::PROCESS_PERSON>(process_person);
 
     std::cout << "\n=== Registering Service ===" << std::endl;
     if (!server.register_service()) {

--- a/qemu_share/test/test_copy_server.cpp
+++ b/qemu_share/test/test_copy_server.cpp
@@ -22,12 +22,21 @@ tracked_int add_impl(tracked_int &a, tracked_int &b) {
   return result;
 }
 
-void process_person(global_ptr<tracked_person> &person) {
-  std::cout << "Person addr is at " << &person->get() << std::endl;
-  person->get().age+=1;
-  person->get().salary+=100;
-  person->get().kill_count+=1;
-  person->printStats();
+// Copy from local to remote
+Person process_person(Person &person) {
+  std::cout << "Person addr is at " << &person << std::endl;
+  person.age+=1;
+  person.salary+=100;
+  person.kill_count+=1;
+  return person;
+}
+
+// Data already remote
+void process_shm_person(global_ptr<Person> &person) {
+  std::cout << "Person addr is at " << &person << std::endl;
+  person->age+=1;
+  person->salary+=100;
+  person->kill_count+=1;
 }
 
 int main(int argc, char *argv[]) {
@@ -43,6 +52,7 @@ int main(int argc, char *argv[]) {
 
     server.register_rpc_function<TestCopyFunctions::ADD>(add_impl);
     server.register_rpc_function<TestCopyFunctions::PROCESS_PERSON>(process_person);
+    server.register_rpc_function<TestCopyFunctions::PROCESS_SHM_PERSON>(process_shm_person);
 
     std::cout << "\n=== Registering Service ===" << std::endl;
     if (!server.register_service()) {


### PR DESCRIPTION
In this PR, we expose a simple shmalloc API using a global_ptr class. The global_ptr class uses a thread local offset to transparently handle -> and * for both server and client. This is because the server/client have different absolute addresses for where the bar 2 is mapped at, by storing this offset at a static thread local variable and using this offset in the overloaded * and -> operators, there is no need to break the RPC API by passing in the offset at the time of the call.

This PR does not provide support for common STL containers.
Technically, the global_ptr is itself an array of type T, and is not a std::vector and so forth. Using stuff like a std::vector is tricky, because it would point to heap memory which is not shared. Because we do a trivial copy (using the mmio_write method), we do not perform a deep copy. So passing in std::vector (as either by value or by global_ptr) actually will not work. So this remains on our TODO. All "containers" that are passed by value, must be trivially copyable. So, something like the std::array would work.

Next, some performance benchmarking was done, and the global_ptr approach actually induces a lot of overhead. An example was with comparing a summation of a std::array and a global_ptr. Because of the need to access the thread_local, barring the cost of copying the array (which is more expensive than just copying the global_ptr), the summation is actually faster for the std::array as we scale input. So we have somewhat achieved zero-copy with the simple shmalloc API, but it is good to note the current inefficiencies.

Finally, we also fixed a bug with the setting up of the server/client channel. The details are in the commit bed2e36302ba1e045e509f4fd4b1d6685dc0c3a8